### PR TITLE
Add access key auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ CONTEXT_SIZE="128000"
 
 # If you want to use fireworks.ai's DeepSeek R1 model:
 # FIREWORKS_KEY="YOUR_KEY"
+
+# Key required for API access
+ACCESS_KEY="CHANGE_ME"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ FIRECRAWL_KEY="your_firecrawl_key"
 # FIRECRAWL_BASE_URL="http://localhost:3002"
 
 OPENAI_KEY="your_openai_key"
+ACCESS_KEY="choose_a_strong_key"
 ```
 
 To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOINT` and `OPENAI_MODEL`:
@@ -180,6 +181,9 @@ CUSTOM_MODEL="custom_model"
 ### Web API
 
 Run `npm run api` to start the API server on port `3051` (or the value of the `PORT` environment variable).
+
+All requests must include an `Authorization` header containing the value of your
+`ACCESS_KEY`.
 
 #### Start a report job
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,10 +13,22 @@ import { generateFeedback } from './feedback';
 
 const app = express();
 const port = process.env.PORT || 3051;
+const accessKey = process.env.ACCESS_KEY;
 
 // Middleware
 app.use(cors());
 app.use(express.json());
+
+app.use((req, res, next) => {
+  if (!accessKey) {
+    return next();
+  }
+  const header = req.get('Authorization');
+  if (header === accessKey || header === `Bearer ${accessKey}`) {
+    return next();
+  }
+  return res.status(401).json({ error: 'Unauthorized' });
+});
 
 // Helper function for consistent logging
 function log(...args: any[]) {


### PR DESCRIPTION
## Summary
- secure API with access key header
- document ACCESS_KEY variable in setup guide
- outline required Authorization header for API usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683b405dbd84832eac00b64b372fa693