### PR TITLE
Add per-job logging support

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,25 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+const storage = new AsyncLocalStorage<string | undefined>();
+const jobLogs: Record<string, string[]> = {};
+
+export function withJobContext<T>(jobId: string, fn: () => Promise<T>): Promise<T> {
+  return storage.run(jobId, fn);
+}
+
+export function getJobLogs(jobId: string): string[] {
+  return jobLogs[jobId] ?? [];
+}
+
 export function log(...args: any[]) {
-  console.log(...args);
+  const message = args
+    .map(arg => (typeof arg === 'string' ? arg : JSON.stringify(arg, null, 2)))
+    .join(' ');
+  console.log(message);
+
+  const jobId = storage.getStore();
+  if (jobId) {
+    jobLogs[jobId] = jobLogs[jobId] ?? [];
+    jobLogs[jobId].push(message);
+  }
 }


### PR DESCRIPTION
## Summary
- improve logger to capture messages per job using `AsyncLocalStorage`
- allow jobs to track log output
- expose logs via API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683bf50601e0832ea7db7d3b35f40860