### PR TITLE
Improve JSON parsing reliability

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,24 @@
+import { generateObject } from 'ai';
+import { log } from './logger';
+
+/**
+ * Wrapper around `generateObject` that retries on JSON parse errors.
+ * Some language models occasionally return malformed JSON which causes
+ * `generateObject` to throw. This helper retries the call a few times
+ * before ultimately propagating the error.
+ */
+export async function generateObjectWithRetry<T>(
+  options: any,
+  retries = 2,
+): Promise<any> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await generateObject<T>(options);
+    } catch (err) {
+      lastError = err;
+      log(`generateObject attempt ${attempt + 1} failed`, err);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- implement `generateObjectWithRetry` helper
- use retry logic when generating SERP queries, learnings, final report, and final answer

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@ai-sdk/fireworks')*

------
https://chatgpt.com/codex/tasks/task_b_683c01e6bdf8832ebd96561888cb07fa