### PR TITLE
Fix report failures by chunking and file endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ coverage
 out/
 build
 dist
+reports/
 
 
 # Debug


### PR DESCRIPTION
## Summary
- generate final reports in smaller chunks to avoid model output limits
- save reports to `reports/` and return a URL
- expose new `/api/reports/:id` endpoint to fetch report files
- ignore generated reports directory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683d72ef2520832e8762113740215149