### PR TITLE
Serve reports via URL only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ FIRECRAWL_KEY="YOUR_KEY"
 OPENAI_KEY="YOUR_KEY"
 CONTEXT_SIZE="128000"
 
+# Optional: customize how many learnings are processed per section when generating reports
+# REPORT_CHUNK_SIZE="20"
+
 # If you want to use other OpenAI compatible API, add the following below:
 # OPENAI_ENDPOINT="http://localhost:11434/v1"
 # CUSTOM_MODEL="llama3.1"

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ coverage
 out/
 build
 dist
+reports/
 
 
 # Debug

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ flowchart TB
 - **Depth & Breadth Control**: Configurable parameters to control how wide (breadth) and deep (depth) the research goes
 - **Smart Follow-up**: Generates follow-up questions to better understand research needs
 - **Comprehensive Reports**: Produces detailed markdown reports with findings and sources
+- **Persistent Reports**: Completed reports are saved to disk and can be downloaded via `/api/reports/{id}`
 - **Concurrent Processing**: Handles multiple searches and result processing in parallel for efficiency
 
 ## Requirements
@@ -101,6 +102,8 @@ FIRECRAWL_KEY="your_firecrawl_key"
 
 OPENAI_KEY="your_openai_key"
 ACCESS_KEY="choose_a_strong_key"
+# Optional: control how many learnings are processed per report section
+# REPORT_CHUNK_SIZE="20"
 ```
 
 To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOINT` and `OPENAI_MODEL`:
@@ -215,7 +218,12 @@ Fetch `/api/jobs/{jobId}` until the status changes to `completed`:
 curl http://localhost:3051/api/jobs/<jobId>
 ```
 
-When finished, the response will include the generated Markdown report.
+When finished, the response will include a `reportUrl` field. Fetch this URL to
+download the saved Markdown report:
+
+```bash
+curl http://localhost:3051/api/reports/<jobId> > report.md
+```
 
 ## How It Works
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,8 @@
 import cors from 'cors';
 import express, { Request, Response } from 'express';
+import fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import path from 'path';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -15,6 +18,10 @@ import { log, withJobContext, getJobLogs } from './logger';
 const app = express();
 const port = process.env.PORT || 3051;
 const accessKey = process.env.ACCESS_KEY;
+const reportsDir = path.join(process.cwd(), 'reports');
+if (!existsSync(reportsDir)) {
+  mkdirSync(reportsDir, { recursive: true });
+}
 
 // Middleware
 app.use(cors());
@@ -81,6 +88,7 @@ interface Job {
   status: JobStatus;
   progress?: ResearchProgress;
   report?: string;
+  reportUrl?: string;
   error?: string;
   followUpQuestions?: string[];
   query?: string;
@@ -203,12 +211,17 @@ ${job.followUpQuestions
         visitedUrls,
       });
 
+      const reportPath = path.join(reportsDir, `${id}.md`);
+      await fs.writeFile(reportPath, report, 'utf-8');
+      const reportUrl = `/api/reports/${id}`;
+
       const reportTime = Date.now() - reportStartTime;
       console.log(`[CONSOLE] Report generated for job ${id} in ${reportTime}ms`);
 
       clearTimeout(jobTimeout);
       job.status = 'completed';
-      job.report = report;
+      job.reportUrl = reportUrl;
+      delete job.report;
       console.log(`[CONSOLE] ====== JOB ${id} COMPLETED SUCCESSFULLY ======`);
       log(`Job ${id} completed successfully`);
       
@@ -264,11 +277,20 @@ app.get('/api/jobs/:id', (req: Request, res: Response) => {
     return res.status(404).json({ error: 'Job not found' });
   }
 
-  return res.json({ ...job, logs: getJobLogs(req.params.id) });
+  const { report, ...jobData } = job;
+  return res.json({ ...jobData, logs: getJobLogs(req.params.id) });
 });
 
 app.get('/api/jobs/:id/logs', (req: Request, res: Response) => {
   return res.json({ logs: getJobLogs(req.params.id) });
+});
+
+app.get('/api/reports/:id', (req: Request, res: Response) => {
+  const file = path.join(reportsDir, `${req.params.id}.md`);
+  if (!existsSync(file)) {
+    return res.status(404).json({ error: 'Report not found' });
+  }
+  return res.sendFile(file);
 });
 
 // Debug endpoint to list all jobs


### PR DESCRIPTION
## Summary
- save final reports to disk but don't keep them in memory
- remove report content from `/api/jobs/:id` responses
- document report retrieval endpoint and chunk size option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683d72ef2520832e8762113740215149