### PR TITLE
Improve JSON parsing in generateObjectWithRetry

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,15 +10,37 @@ import { log } from './logger';
 export async function generateObjectWithRetry<T>(
   options: any,
   retries = 2,
-): Promise<any> {
+): Promise<T> {
   let lastError: unknown;
+
+  const extractJSON = (text: string) => {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  };
+
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       return await generateObject<T>(options);
-    } catch (err) {
+    } catch (err: any) {
       lastError = err;
       log(`generateObject attempt ${attempt + 1} failed`, err);
+
+      // Try to salvage JSON if the model returned malformed output
+      const text = err?.cause?.text ?? err?.text ?? '';
+      if (typeof text === 'string' && text.trim()) {
+        const parsed = extractJSON(text);
+        if (parsed) {
+          log('Successfully extracted JSON from malformed response');
+          return parsed as T;
+        }
+      }
     }
   }
+
   throw lastError;
 }


### PR DESCRIPTION
## Summary
- enhance `generateObjectWithRetry` to salvage malformed JSON output

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_b_683db6d55114832eb80dfcd349bedcae