### PR TITLE
Add Unicode PDF CLI and integrate with run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.log*
 *.pem
 bun.lockb
 report.md
+__pycache__/

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs/promises';
 import * as readline from 'readline';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 import { getModel } from './ai/providers';
 import {
@@ -14,6 +16,8 @@ const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 });
+
+const execFileAsync = promisify(execFile);
 
 // Helper function to get user input
 function askQuestion(query: string): Promise<string> {
@@ -108,6 +112,19 @@ ${followUpQuestions.map((q: string, i: number) => `Q: ${q}\nA: ${answers[i]}`).j
     await fs.writeFile('report.md', report, 'utf-8');
     log(`\n\nFinal Report:\n\n${report}`);
     log('\nReport has been saved to report.md');
+
+    // Also generate a PDF using the Python helper
+    try {
+      await execFileAsync('python3', [
+        '-m',
+        'utils.pdf_utils',
+        'report.md',
+        'report.pdf',
+      ]);
+      log('Report PDF has been saved to report.pdf');
+    } catch {
+      log('Failed to generate report.pdf');
+    }
   } else {
     const answer = await writeFinalAnswer({
       prompt: combinedQuery,
@@ -117,6 +134,19 @@ ${followUpQuestions.map((q: string, i: number) => `Q: ${q}\nA: ${answers[i]}`).j
     await fs.writeFile('answer.md', answer, 'utf-8');
     log(`\n\nFinal Answer:\n\n${answer}`);
     log('\nAnswer has been saved to answer.md');
+
+    // Also generate a PDF using the Python helper
+    try {
+      await execFileAsync('python3', [
+        '-m',
+        'utils.pdf_utils',
+        'answer.md',
+        'answer.pdf',
+      ]);
+      log('Answer PDF has been saved to answer.pdf');
+    } catch {
+      log('Failed to generate answer.pdf');
+    }
   }
 
   if (process.argv[2] !== 'api') {

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+
+"""Helper utilities for the research agent."""
+
+from .pdf_utils import UnicodePDF, text_to_pdf
+
+__all__ = ["UnicodePDF", "text_to_pdf"]

--- a/utils/pdf_utils.py
+++ b/utils/pdf_utils.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from typing import Optional
+import sys
+
+from fpdf import FPDF
+
+# Use DejaVuSans font which supports a wide range of Unicode characters
+DEFAULT_FONT_PATH = Path('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf')
+
+class UnicodePDF(FPDF):
+    """FPDF subclass with DejaVuSans loaded for Unicode support."""
+
+    def __init__(self, font_path: Optional[str] = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        font_path = font_path or str(DEFAULT_FONT_PATH)
+        # Register DejaVuSans as a Unicode font
+        self.add_font('DejaVu', '', font_path, uni=True)
+        self.set_font('DejaVu', '', 12)
+
+    def add_unicode_page(self) -> None:
+        """Convenience to add a page and set the Unicode font."""
+        self.add_page()
+        self.set_font('DejaVu', '', 12)
+
+def text_to_pdf(text: str, output_path: str, font_path: Optional[str] = None) -> None:
+    """Render text to a PDF file using a Unicode font."""
+    pdf = UnicodePDF(font_path=font_path)
+    pdf.add_unicode_page()
+    pdf.write(5, text)
+    pdf.output(output_path)
+
+
+def _main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: python -m utils.pdf_utils <input.txt> <output.pdf>")
+        raise SystemExit(1)
+
+    text = Path(sys.argv[1]).read_text(encoding="utf-8")
+    text_to_pdf(text, sys.argv[2])
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## Summary
- expose PDF helper from `utils` package
- add a simple CLI to `utils/pdf_utils.py`
- generate report and answer PDFs from `src/run.ts`

## Testing
- `npm run test` *(fails: Error: no test specified)*
- `python3 -m utils.pdf_utils` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_b_68490c4583a4832eaa2d98665082714b